### PR TITLE
adding remote tracking to branches.

### DIFF
--- a/canticles/get.go
+++ b/canticles/get.go
@@ -29,7 +29,7 @@ var get = NewGet()
 
 var GetCommand = &Command{
 	Name:             "get",
-	UsageLine:        "get [-v] [-u] [-source] [-limit <n>]",
+	UsageLine:        "get [-v] [-u] [-source] [-limit <n>] [-track=true]",
 	ShortDescription: "download dependencies as defined in the Canticle file",
 	LongDescription: `The get command fetches dependencies. When issued locally it looks...
 

--- a/canticles/get.go
+++ b/canticles/get.go
@@ -29,7 +29,7 @@ var get = NewGet()
 
 var GetCommand = &Command{
 	Name:             "get",
-	UsageLine:        "get [-v] [-u] [-source] [-limit <n>] [-track=true]",
+	UsageLine:        "get [-v] [-u] [-source] [-limit <n>]",
 	ShortDescription: "download dependencies as defined in the Canticle file",
 	LongDescription: `The get command fetches dependencies. When issued locally it looks...
 

--- a/canticles/vcs.go
+++ b/canticles/vcs.go
@@ -48,12 +48,6 @@ type VCSCmd struct {
 	ParseRegex *regexp.Regexp
 }
 
-// ShellCmd is used to exec shell commands that can't easily be done through git porcelain commands.
-type ShellCmd struct {
-	Name string
-	Cmd  string
-}
-
 // ExecWithArgs overriden from the default
 func (vc *VCSCmd) ExecWithArgs(repo string, args []string) (string, error) {
 	LogVerbose("Running command: %s %v in dir %s", vc.Cmd, args, repo)

--- a/canticles/vcs.go
+++ b/canticles/vcs.go
@@ -48,6 +48,12 @@ type VCSCmd struct {
 	ParseRegex *regexp.Regexp
 }
 
+// ShellCmd is used to exec shell commands that can't easily be done through git porcelain commands.
+type ShellCmd struct {
+	Name string
+	Cmd  string
+}
+
 // ExecWithArgs overriden from the default
 func (vc *VCSCmd) ExecWithArgs(repo string, args []string) (string, error) {
 	LogVerbose("Running command: %s %v in dir %s", vc.Cmd, args, repo)
@@ -316,6 +322,11 @@ func GetGitBranches(path string) ([]string, error) {
 			}
 		}
 	}
+	// this adds remote tracking for all the branches.
+	branches := "for branch in `git branch -a | grep remotes | grep -v HEAD | grep -v master`; do git branch --track ${branch##*/} $branch; done"
+	cmd = exec.Command("/bin/bash", "-c", branches)
+	cmd.Start()
+
 	return results, nil
 }
 


### PR DESCRIPTION
This should track remote branches, which git does not do by default.